### PR TITLE
Stop dropping prefix from names

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -343,7 +343,7 @@ impl Document {
                     });
                 }
                 Ok(ref x @ (Event::Start(ref e) | Event::Empty(ref e))) => {
-                    let name: QName = std::str::from_utf8(e.name().local_name().into_inner())
+                    let name: QName = std::str::from_utf8(e.name().into_inner())
                         .unwrap()
                         .parse()
                         .unwrap();
@@ -371,7 +371,7 @@ impl Document {
 
                     for attr in e.attributes().filter_map(Result::ok) {
                         let value = attr.unescape_value().unwrap();
-                        let s = std::str::from_utf8(attr.key.local_name().into_inner())?;
+                        let s = std::str::from_utf8(attr.key.into_inner())?;
 
                         root.set_attribute(&mut document, s, &value);
                     }
@@ -411,7 +411,7 @@ impl Document {
         loop {
             match r.read_event_into(&mut buf) {
                 Ok(Event::Start(e)) => {
-                    let name: QName = std::str::from_utf8(e.name().local_name().into_inner())
+                    let name: QName = std::str::from_utf8(e.name().into_inner())
                         .unwrap()
                         .parse()
                         .unwrap();
@@ -427,7 +427,7 @@ impl Document {
                     for attr in e.attributes().filter_map(Result::ok) {
                         let value = attr.unescape_value()?.to_string();
                         attrs.insert(
-                            std::str::from_utf8(attr.key.local_name().into_inner())
+                            std::str::from_utf8(attr.key.into_inner())
                                 .unwrap()
                                 .parse()
                                 .unwrap(),
@@ -439,7 +439,7 @@ impl Document {
                     element_stack.push(element);
                 }
                 Ok(Event::Empty(e)) => {
-                    let name: QName = std::str::from_utf8(e.name().local_name().into_inner())
+                    let name: QName = std::str::from_utf8(e.name().into_inner())
                         .unwrap()
                         .parse()
                         .unwrap();
@@ -455,7 +455,7 @@ impl Document {
                     for attr in e.attributes().filter_map(Result::ok) {
                         let value = attr.unescape_value()?.to_string();
                         attrs.insert(
-                            std::str::from_utf8(attr.key.local_name().into_inner())
+                            std::str::from_utf8(attr.key.into_inner())
                                 .unwrap()
                                 .parse()
                                 .unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,4 +293,40 @@ mod tests {
         let sel = Selector::new(r#"string[name="english_ime_name"]"#).unwrap();
         let _el = doc.root().query_selector(&doc, &sel).unwrap();
     }
+
+    #[test]
+    fn non_root_empty_element_name() {
+        let input = r#"<root><elem/><x:elem/></root>"#;
+        let doc = Document::from_str(input).unwrap();
+
+        let nq_elem = doc.root().children(&doc)[0];
+        assert_eq!(nq_elem.qname(&doc).namespace(), None);
+        assert_eq!(nq_elem.prefix(&doc), None);
+        assert_eq!(nq_elem.qname(&doc).local_part(), "elem");
+        assert_eq!(nq_elem.name(&doc), "elem");
+
+        let q_elem = doc.root().children(&doc)[1];
+        assert_eq!(q_elem.qname(&doc).namespace(), Some("x"));
+        assert_eq!(q_elem.prefix(&doc), Some("x"));
+        assert_eq!(q_elem.qname(&doc).local_part(), "elem");
+        assert_eq!(q_elem.name(&doc), "x:elem");
+    }
+
+    #[test]
+    fn non_root_non_empty_element_name() {
+        let input = r#"<root><elem></elem><x:elem></x:elem></root>"#;
+        let doc = Document::from_str(input).unwrap();
+
+        let nq_elem = doc.root().children(&doc)[0];
+        assert_eq!(nq_elem.qname(&doc).namespace(), None);
+        assert_eq!(nq_elem.prefix(&doc), None);
+        assert_eq!(nq_elem.qname(&doc).local_part(), "elem");
+        assert_eq!(nq_elem.name(&doc), "elem");
+
+        let q_elem = doc.root().children(&doc)[1];
+        assert_eq!(q_elem.qname(&doc).namespace(), Some("x"));
+        assert_eq!(q_elem.prefix(&doc), Some("x"));
+        assert_eq!(q_elem.qname(&doc).local_part(), "elem");
+        assert_eq!(q_elem.name(&doc), "x:elem");
+    }
 }


### PR DESCRIPTION
Since 8338f317, `xmlem` drops namespaces when storing elements’ and attributes’ names.

This PR:

-   Restores the correct parsing so that stored `QName`s have namespace information.
-   Adds (basic) documentation of (part of) the methods dealing with `QName`s.
-   Adds tests for the restored behavior (<ins>including</ins> as part of the documentation).
-   Adds an `Element::qname` method, giving access to the underlying `QName`.

That last point is because part of my original use case was accessing the local part, which is not exposed currently (except by the now-fixed `Element::name`). Given that `QName` is already exposed through `Element::attributes`, I find more natural to give access to the `QName`, but providing `Element::local_name` would be equivalent and I can change if you prefer.