### PR TITLE
Avoid panic on processing instructions before root

### DIFF
--- a/src/document.rs
+++ b/src/document.rs
@@ -404,6 +404,9 @@ impl Document {
                         nodes.insert(NodeValue::CData(text.to_owned())),
                     )));
                 }
+                Ok(Event::PI(_)) => {
+                    continue;
+                }
                 Ok(x) => {
                     panic!("Uhh... {:?}", x);
                 }

--- a/src/document.rs
+++ b/src/document.rs
@@ -407,8 +407,8 @@ impl Document {
                 Ok(Event::PI(_)) => {
                     continue;
                 }
-                Ok(x) => {
-                    panic!("Uhh... {:?}", x);
+                Ok(other @ (Event::Eof | Event::End(_))) => {
+                    return Err(ReadError::Unexpected(format!("{other:?}")))
                 }
                 Err(e) => return Err(e.into()),
             }
@@ -551,6 +551,7 @@ impl std::str::FromStr for Document {
 pub enum ReadError {
     Parse(quick_xml::Error),
     SupplementaryElement(String),
+    Unexpected(String),
 }
 
 impl fmt::Display for ReadError {
@@ -559,6 +560,9 @@ impl fmt::Display for ReadError {
             ReadError::Parse(err) => fmt::Display::fmt(err, f),
             ReadError::SupplementaryElement(name) => {
                 write!(f, "Supplementary element after root: {name}")
+            }
+            ReadError::Unexpected(description) => {
+                write!(f, "Unexpected: {description}")
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -348,4 +348,10 @@ mod tests {
         Document::from_str(r#"<?xml-stylesheet href="style.css" type="text/css"?><root/>"#)
             .unwrap();
     }
+
+    #[test]
+    fn invalid_errors() {
+        Document::from_str(r#""#).unwrap_err();
+        Document::from_str(r#"</root>"#).unwrap_err();
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,4 +342,10 @@ mod tests {
         let doc = Document::from_str(EXACT_XML).unwrap();
         assert_eq!(doc.to_string(), EXACT_XML);
     }
+
+    #[test]
+    fn accepts_pi_before_root() {
+        Document::from_str(r#"<?xml-stylesheet href="style.css" type="text/css"?><root/>"#)
+            .unwrap();
+    }
 }


### PR DESCRIPTION
Processing instructions are allowed in the prolog of a document per [XML 1.0 section 2.8](https://www.w3.org/TR/xml/#sec-prolog-dtd) and at least `<?xml-stylesheet?>` [needs to sit there](https://www.w3.org/TR/xml-stylesheet/#the-xml-stylesheet-processing-instruction) in order to guarantee consideration by processors.

Before this PR, `xmlem` would panic with something like `Uhh... PI(BytesPI { content: Borrowed("xml-stylesheet href=\"style.css\" type=\"text/css\"") })` on such prolog PIs.

Ideally, PIs should be exposed to the user of `xmlem` ([it is important enough for the spec to say “must”](https://www.w3.org/TR/xml/#sec-pi)), but since  PIs in other positions are currently ignored (and I don’t currently have a use case beyond not crashing), this PR simply ignores prolog PIs.